### PR TITLE
Add support ssh_args and skipping hourly backups

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,7 @@ rsnapshot_logfile: /var/log/rsnapshot
 rsnapshot_lockfile: /var/run/rsnapshot.pid
 # rsync_short_args       -a
 # rsync_long_args        --delete --numeric-ids --relative --delete-excluded
+rsnapshot_ssh_args: ""
 # ssh_args       -p 22
 # ssh_args       -o BatchMode=yes
 # du_args        -csh

--- a/templates/rsnapshot-test.conf.j2
+++ b/templates/rsnapshot-test.conf.j2
@@ -18,7 +18,9 @@ cmd_logger	{{ rsnapshot_cmd_logger }}
 #linux_lvm_cmd_lvremove	/path/to/lvremove
 #linux_lvm_cmd_mount	/sbin/mount
 #linux_lvm_cmd_umount	/sbin/umount
+{% if rsnapshot_retain_hourly != "" %}
 retain		hourly	{{ rsnapshot_retain_hourly }}
+{% endif %}
 retain		daily	{{ rsnapshot_retain_daily }}
 retain		weekly	{{ rsnapshot_retain_weekly }}
 retain		monthly	{{ rsnapshot_retain_monthly }}

--- a/templates/rsnapshot-test.conf.j2
+++ b/templates/rsnapshot-test.conf.j2
@@ -30,6 +30,9 @@ logfile		{{ rsnapshot_logfile }}
 lockfile	{{ rsnapshot_lockfile }}
 #rsync_short_args	-a
 #rsync_long_args	--delete --numeric-ids --relative --delete-excluded
+{% if rsnapshot_ssh_args != "" %}
+ssh_args	{{ rsnapshot_ssh_args }}
+{% endif %}
 #ssh_args	-p 22
 #ssh_args	-o BatchMode=yes
 #du_args	-csh

--- a/templates/rsnapshot.conf.j2
+++ b/templates/rsnapshot.conf.j2
@@ -18,7 +18,9 @@ cmd_logger	{{ rsnapshot_cmd_logger }}
 #linux_lvm_cmd_lvremove	/path/to/lvremove
 #linux_lvm_cmd_mount	/sbin/mount
 #linux_lvm_cmd_umount	/sbin/umount
+{% if rsnapshot_retain_hourly != "" %}
 retain		hourly	{{ rsnapshot_retain_hourly }}
+{% endif %}
 retain		daily	{{ rsnapshot_retain_daily }}
 retain		weekly	{{ rsnapshot_retain_weekly }}
 retain		monthly	{{ rsnapshot_retain_monthly }}

--- a/templates/rsnapshot.conf.j2
+++ b/templates/rsnapshot.conf.j2
@@ -30,6 +30,9 @@ logfile		{{ rsnapshot_logfile }}
 lockfile	{{ rsnapshot_lockfile }}
 #rsync_short_args	-a
 #rsync_long_args	--delete --numeric-ids --relative --delete-excluded
+{% if rsnapshot_ssh_args != "" %}
+ssh_args	{{ rsnapshot_ssh_args }}
+{% endif %}
 #ssh_args	-p 22
 #ssh_args	-o BatchMode=yes
 #du_args	-csh


### PR DESCRIPTION
This PR combines two small features into one. Let me know if you want to spit them into separate PRs:

1. Add new variable *rsnapshot_ssh_args* which, if set to a non-empty string, will be passed to *ssh_args* in *rsnapshot.conf*
2. Allow omitting the "retain hourly <value>" line in *rsnapshot.conf* if the variable *rsnapshot_retain_hourly* is set to an empty string.

These changes do not change existing behavior.